### PR TITLE
Modify the agent/subject endpoints for create and update to report on conflicting records.

### DIFF
--- a/backend/app/controllers/agent_corporate_entity.rb
+++ b/backend/app/controllers/agent_corporate_entity.rb
@@ -7,7 +7,9 @@ class ArchivesSpaceService < Sinatra::Base
     .returns([200, :created],
              [400, :error]) \
   do
-    handle_create(AgentCorporateEntity, params[:agent])
+    with_record_conflict_reporting(AgentCorporateEntity, params[:agent]) do
+      handle_create(AgentCorporateEntity, params[:agent])
+    end
   end
 
 
@@ -30,7 +32,9 @@ class ArchivesSpaceService < Sinatra::Base
     .returns([200, :updated],
              [400, :error]) \
   do
-    handle_update(AgentCorporateEntity, params[:id], params[:agent])
+    with_record_conflict_reporting(AgentCorporateEntity, params[:agent]) do
+      handle_update(AgentCorporateEntity, params[:id], params[:agent])
+    end
   end
 
 

--- a/backend/app/controllers/agent_family.rb
+++ b/backend/app/controllers/agent_family.rb
@@ -7,7 +7,9 @@ class ArchivesSpaceService < Sinatra::Base
     .returns([200, :created],
              [400, :error]) \
   do
-    handle_create(AgentFamily, params[:agent])
+    with_record_conflict_reporting(AgentFamily, params[:agent]) do
+      handle_create(AgentFamily, params[:agent])
+    end
   end
 
 
@@ -30,7 +32,9 @@ class ArchivesSpaceService < Sinatra::Base
     .returns([200, :updated],
              [400, :error]) \
   do
-    handle_update(AgentFamily, params[:id], params[:agent])
+    with_record_conflict_reporting(AgentFamily, params[:agent]) do
+      handle_update(AgentFamily, params[:id], params[:agent])
+    end
   end
 
 

--- a/backend/app/controllers/agent_person.rb
+++ b/backend/app/controllers/agent_person.rb
@@ -7,7 +7,9 @@ class ArchivesSpaceService < Sinatra::Base
     .returns([200, :created],
              [400, :error]) \
   do
-    handle_create(AgentPerson, params[:agent])
+    with_record_conflict_reporting(AgentPerson, params[:agent]) do
+      handle_create(AgentPerson, params[:agent])
+    end
   end
 
 
@@ -30,7 +32,9 @@ class ArchivesSpaceService < Sinatra::Base
     .returns([200, :updated],
              [400, :error]) \
   do
-    handle_update(AgentPerson, params[:id], params[:agent])
+    with_record_conflict_reporting(AgentPerson, params[:agent]) do
+      handle_update(AgentPerson, params[:id], params[:agent])
+    end
   end
 
 

--- a/backend/app/controllers/agent_software.rb
+++ b/backend/app/controllers/agent_software.rb
@@ -7,7 +7,9 @@ class ArchivesSpaceService < Sinatra::Base
     .returns([200, :created],
              [400, :error]) \
   do
-    handle_create(AgentSoftware, params[:agent])
+    with_record_conflict_reporting(AgentSoftware, params[:agent]) do
+      handle_create(AgentSoftware, params[:agent])
+    end
   end
 
 
@@ -30,7 +32,9 @@ class ArchivesSpaceService < Sinatra::Base
     .returns([200, :updated],
              [400, :error]) \
   do
-    handle_update(AgentSoftware, params[:id], params[:agent])
+    with_record_conflict_reporting(AgentSoftware, params[:agent]) do
+      handle_update(AgentSoftware, params[:id], params[:agent])
+    end
   end
 
 

--- a/backend/app/controllers/subject.rb
+++ b/backend/app/controllers/subject.rb
@@ -8,7 +8,9 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:update_subject_record])
     .returns([200, :updated]) \
   do
-    handle_update(Subject, params[:id], params[:subject])
+    with_record_conflict_reporting(Subject, params[:subject]) do
+      handle_update(Subject, params[:id], params[:subject])
+    end
   end
 
 
@@ -18,7 +20,9 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:update_subject_record])
     .returns([200, :created]) \
   do
-    handle_create(Subject, params[:subject])
+    with_record_conflict_reporting(Subject, params[:subject]) do
+      handle_create(Subject, params[:subject])
+    end
   end
 
 

--- a/backend/app/lib/crud_helpers.rb
+++ b/backend/app/lib/crud_helpers.rb
@@ -70,6 +70,24 @@ module CrudHelpers
     end
   end
 
+
+  def with_record_conflict_reporting(model, json)
+    begin
+      yield
+    rescue Sequel::ValidationFailed => e
+      if e.errors && e.errors.any? {|key, errors| errors[0].end_with?("must be unique")}
+        existing_record = model.find_matching(json)
+
+        if existing_record
+          e.errors[:conflicting_record] = [existing_record.uri]
+        end
+      end
+
+      raise $!
+    end
+  end
+
+
   private
 
   def listing_response(dataset, model)

--- a/backend/app/model/mixins/agent_manager.rb
+++ b/backend/app/model/mixins/agent_manager.rb
@@ -175,7 +175,7 @@ module AgentManager
                       
 
           else
-            agent = find(:agent_sha1 => calculate_hash(json))
+            agent = find_matching(json)
           end
 
           if !agent
@@ -191,6 +191,11 @@ module AgentManager
           agent
         
         }
+      end
+
+
+      def find_matching(json)
+        find(:agent_sha1 => calculate_hash(json))
       end
 
 

--- a/backend/app/model/subject.rb
+++ b/backend/app/model/subject.rb
@@ -70,11 +70,7 @@ class Subject < Sequel::Model(:subject)
     DB.attempt {
       self.create_from_json(json)
     }.and_if_constraint_fails {|exception|
-      source_id = BackendEnumSource.id_for_value("subject_source", json.source)
-
-      subject = Subject.find(:vocab_id => JSONModel(:vocabulary).id_for(json.vocabulary),
-                             :terms_sha1 => generate_terms_sha1(json),
-                             :source_id => source_id)
+      subject = find_matching(json)
 
       if !subject
         # The subject exists but we can't find it.  This could mean it was
@@ -87,6 +83,15 @@ class Subject < Sequel::Model(:subject)
 
       subject
     }
+  end
+
+
+  def self.find_matching(json)
+    source_id = BackendEnumSource.id_for_value("subject_source", json.source)
+
+    Subject.find(:vocab_id => JSONModel(:vocabulary).id_for(json.vocabulary),
+                 :terms_sha1 => generate_terms_sha1(json),
+                 :source_id => source_id)
   end
 
 

--- a/backend/spec/controller_conflict_reporting_spec.rb
+++ b/backend/spec/controller_conflict_reporting_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+describe "Conflicting record handling" do
+
+  describe "Subjects" do
+    before(:each) do
+      vocab = JSONModel(:vocabulary).from_hash("name" => "Cool Vocab",
+                                               "ref_id" => "coolid"
+                                              )
+      vocab.save
+      @vocab_id = vocab.id
+    end
+
+    let (:subject_properties) do
+      {
+        :terms => [build(:json_term, "term" => "1981 Heroes")],
+        :vocabulary => JSONModel(:vocabulary).uri_for(@vocab_id),
+        :source => "local"
+      }
+    end
+
+    it "reports conflicting records on create" do
+      subject = create(:json_subject, subject_properties)
+
+      exception = begin
+                    create(:json_subject, subject_properties)
+                    nil
+                  rescue JSONModel::ValidationException => e
+                    e
+                  end
+
+      exception.should_not be(nil)
+      exception.errors['conflicting_record'].should eq([subject.uri])
+    end
+
+
+    it "reports conflicting records on update" do
+      subject_a = create(:json_subject, subject_properties)
+      subject_b = create(:json_subject, subject_properties.merge(:terms => [build(:json_term, "term" => "Non-conflicting")]))
+
+      exception = begin
+                    subject_b[:terms] = subject_properties[:terms]
+                    subject_b.save
+                    nil
+                  rescue JSONModel::ValidationException => e
+                    e
+                  end
+
+      exception.should_not be(nil)
+      exception.errors['conflicting_record'].should eq([subject_a.uri])
+    end
+  end
+
+
+  describe "Agents" do
+    before(:each) do
+    end
+
+    let (:subject_properties) do
+      {
+        :terms => [build(:json_term, "term" => "1981 Heroes")],
+        :vocabulary => JSONModel(:vocabulary).uri_for(@vocab_id),
+        :source => "local"
+      }
+    end
+
+    it "reports conflicting records on create" do
+      AgentManager.registered_agents.each do |agent_type|
+        jsonmodel = agent_type.fetch(:jsonmodel)
+        agent_a = build(:"json_#{jsonmodel}")
+        agent_b = build(:"json_#{jsonmodel}", agent_a.to_hash)
+
+        agent_a.save
+
+        exception = begin
+                      agent_b.save
+                      nil
+                    rescue JSONModel::ValidationException => e
+                      e
+                    end
+
+        exception.should_not be(nil)
+        exception.errors['conflicting_record'].should eq([agent_a.uri])
+      end
+    end
+
+
+    it "reports conflicting records on update" do
+      AgentManager.registered_agents.each do |agent_type|
+        jsonmodel = agent_type.fetch(:jsonmodel)
+        agent_archetype = build(:"json_#{jsonmodel}")
+        agent_a = create(:"json_#{jsonmodel}", agent_archetype.to_hash)
+        agent_b = create(:"json_#{jsonmodel}", agent_archetype.to_hash.merge('names' => build(:"json_#{jsonmodel}")[:names]))
+
+        exception = begin
+                      agent_b[:names] = agent_archetype[:names]
+                      agent_b.save
+                      nil
+                    rescue JSONModel::ValidationException => e
+                      e
+                    end
+
+        exception.should_not be(nil), "No exception on update for #{agent_type}"
+        exception.errors['conflicting_record'].should eq([agent_a.uri])
+      end
+    end
+  end
+
+
+end


### PR DESCRIPTION
Instead of just saying "Subject must be unique" we now additionally
report the URI of the subject that caused the conflict.  Handy!