### PR TITLE
Pineapples plugin hooks

### DIFF
--- a/frontend/app/controllers/application_controller.rb
+++ b/frontend/app/controllers/application_controller.rb
@@ -208,7 +208,7 @@ class ApplicationController < ActionController::Base
                       "linked_events", "linked_events::linked_records",
                       "linked_events::linked_agents",
                       "top_container", "container_profile", "location_profile",
-                      "owner_repo"]
+                      "owner_repo"] + Plugins.fields_to_resolve
     }
   end
 

--- a/frontend/app/helpers/plugin_helper.rb
+++ b/frontend/app/helpers/plugin_helper.rb
@@ -12,6 +12,12 @@ module PluginHelper
         result << '<span class="glyphicon glyphicon-chevron-right"></span></a></li>'
       end
     end
+
+    mode = controller.action_name === 'show' ? :readonly : :edit
+    Plugins.sections_for(record, mode).each do |plugin_section|
+      result << plugin_section.render_sidebar(self, record, mode)
+    end
+
     result.html_safe
   end
 
@@ -27,6 +33,11 @@ module PluginHelper
                            :context => context, :section_id => "#{jsonmodel_type}_#{name}_" })
       end
     end
+
+    Plugins.sections_for(record, :readonly).each do |sub_record|
+      result << sub_record.render_readonly(self, record, context)
+    end
+
     result.html_safe
   end
 
@@ -41,6 +52,11 @@ module PluginHelper
                          :cardinality => parent['cardinality'].intern, :plugin => true})
 
     end
+
+    Plugins.sections_for(context.obj, :edit).each do |sub_record|
+      result << sub_record.render_edit(self, context.obj, context)
+    end
+
     result.html_safe
   end
 

--- a/frontend/app/helpers/search_helper.rb
+++ b/frontend/app/helpers/search_helper.rb
@@ -145,6 +145,10 @@ module SearchHelper
 
 
   def can_edit_search_result?(record)
+    Plugins.edit_roles.each do |edit_role|
+      return user_can?(edit_role.role, record['id']) if record['primary_type'] === edit_role.jsonmodel_type
+    end
+
     return user_can?('update_container_record', record['id']) if record['primary_type'] === "top_container"
     return user_can?('manage_repository', record['id']) if record['primary_type'] === "repository"
     return user_can?('update_location_record') if record['primary_type'] === "location"

--- a/frontend/app/views/search/_embedded.html.erb
+++ b/frontend/app/views/search/_embedded.html.erb
@@ -3,9 +3,10 @@
   html_search_url = url_for({:controller => :search, :action => :do_search}.merge(build_search_params({"add_filter_term" => filter_term})))
 
   heading_text = "Linked Records" if heading_text.blank?
+  section_id = "search_embedded" if section_id.blank?
 %>
 
-<section id="search_embedded" class="subrecord-form-dummy">
+<section id="<%= section_id %>" class="subrecord-form-dummy">
   <h3 class="subrecord-form-heading">
     <%= heading_text %>
     <%= link_to I18n.t("actions.view_search_results"), html_search_url, :class => "btn btn-sm btn-default pull-right" %>

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -32,6 +32,7 @@ module Plugins
 
     @sections = []
     @fields_to_resolve = []
+    @edit_roles = []
   end
 
 
@@ -77,6 +78,17 @@ module Plugins
 
   def self.fields_to_resolve
     @fields_to_resolve
+  end
+
+
+  EditRole = Struct.new(:jsonmodel_type, :role)
+  def self.register_edit_role_for_type(jsonmodel_type, role)
+    @edit_roles << EditRole.new(jsonmodel_type, role)
+  end
+
+
+  def self.edit_roles
+    @edit_roles
   end
 
 

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -31,6 +31,7 @@ module Plugins
     end
 
     @sections = []
+    @fields_to_resolve = []
   end
 
 
@@ -66,6 +67,16 @@ module Plugins
 
   def self.plugins_for(parent)
     @config[:parents][parent] || []
+  end
+
+
+  def self.add_resolve_field(field_name)
+    @fields_to_resolve += ASUtils.wrap(field_name)
+  end
+
+
+  def self.fields_to_resolve
+    @fields_to_resolve
   end
 
 

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -29,6 +29,8 @@ module Plugins
     if @config[:repository_menu_items].length > 0
       puts "Found repository menu items for plug-ins: #{repository_menu_items.inspect}"
     end
+
+    @sections = []
   end
 
 
@@ -66,6 +68,136 @@ module Plugins
     @config[:parents][parent] || []
   end
 
+
+  def self.register_plugin_section(plugin_section)
+    @sections << plugin_section
+  end
+
+  def self.sections_for(record, mode)
+    @sections.select{|plugin_section| plugin_section.supports?(record, mode)}
+  end
+
+
+  class AbstractPluginSection
+    def initialize(plugin, name, jsonmodel_types, opts = {})
+      @plugin = plugin
+      @name = name
+      @jsonmodel_types = ASUtils.wrap(jsonmodel_types)
+
+      parse_opts(opts)
+    end
+
+    def render_edit(view_context, record, form_context)
+      raise "IMPLEMENT ME"
+    end
+
+    def render_readonly(view_context, record, form_context)
+      raise "IMPLEMENT ME"
+    end
+
+    def render_sidebar(view_context, record, mode)
+      "<li>" +
+        "  <a href='##{build_section_id(record['jsonmodel_type'])}'>" +
+        "    #{@sidebar_label}" +
+        "    <span class='glyphicon glyphicon-chevron-right'></span>" +
+        "  </a>" +
+        "</li>".html_safe
+    end
+
+    def supports?(record, mode)
+      @jsonmodel_types.include?(record['jsonmodel_type']) &&
+        (mode == :edit && @show_on_edit ||
+          mode == :readonly && @show_on_readonly)
+    end
+
+    private
+
+    def parse_opts(opts)
+      @show_on_edit = opts.fetch(:show_on_edit, true)
+      @show_on_readonly = opts.fetch(:show_on_readonly, true)
+      @section_id = opts.fetch(:section_id, nil)
+      @sidebar_label = opts.fetch(:sidebar_label, I18n.t("plugins.#{@plugin}.#{@name}.section"))
+    end
+
+    def build_section_id(jsonmodel_type)
+      @section_id ? @section_id : "#{jsonmodel_type}_#{@name}"
+    end
+  end
+
+
+  class PluginSubRecord < AbstractPluginSection
+
+    def render_edit(view_context, record, form_context)
+      view_context.render_aspace_partial(
+        :partial => "shared/subrecord_form",
+        :locals => {
+          :form => form_context,
+          :name => @jsonmodel_field,
+          :cardinality => @cardinality,
+          :template => @template_name,
+          :template_erb => @erb_edit_template_path,
+          :js_template_name => @js_edit_template_name,
+          :section_id => build_section_id(form_context.obj['jsonmodel_type']),
+        })
+    end
+
+    def render_readonly(view_context, record, form_context)
+      view_context.render_aspace_partial(
+        :partial => @erb_readonly_template_path,
+        :locals => { @jsonmodel_field.intern => record.send(@jsonmodel_field.intern),
+                     :context => form_context,
+                     :section_id => build_section_id(form_context.obj['jsonmodel_type']) })
+    end
+
+    def supports?(record, mode)
+      result = super
+      if result && mode == :readonly
+        Array(record.send(@jsonmodel_field.intern)).length > 0
+      else
+        result
+      end
+    end
+
+    private
+
+    def parse_opts(opts)
+      super
+
+      @jsonmodel_field = opts.fetch(:jsonmodel_field, @name)
+      @cardinality = opts.fetch(:cardinality, :zero_to_many)
+      @template_name = opts.fetch(:template_name, @name)
+      @erb_edit_template_path = opts.fetch(:erb_edit_template_path, "#{@name}/template")
+      @js_edit_template_name = opts.fetch(:js_edit_template_name, "template_#{@name}")
+      @erb_readonly_template_path = opts.fetch(:erb_readonly_template_path, "#{@name}/show_as_subrecords")
+    end
+  end
+
+
+  class PluginReadonlySearch < AbstractPluginSection
+
+    def render_readonly(view_context, record, form_context)
+      view_context.render_aspace_partial(
+        :partial => "search/embedded",
+        :locals => {
+          :record => record,
+          :filter_term => @filter_term_proc.call(record),
+          :heading_text => @heading_text,
+          :section_id => @section_id ? @section_id : build_section_id(form_context.obj['jsonmodel_type']),
+        }
+      )
+    end
+
+    private
+
+    def parse_opts(opts)
+      super
+
+      @show_on_edit = false
+      @filter_term_proc = opts.fetch(:filter_term_proc)
+      @heading_text = opts.fetch(:heading_text)
+    end
+
+  end
 end
 
 Plugins::init

--- a/plugins/PLUGINS_README.md
+++ b/plugins/PLUGINS_README.md
@@ -167,6 +167,36 @@ the `:solr_field` parameter controls which field is used from the
 underlying index.
 
 
+** Frontend Specific Hooks
+
+* `Plugins.add_resolve_field(field_name)` - use this when you have added a new
+field/relationship and you need it to be resolved when the record is retrieved
+from the API.
+
+* `Plugins.register_edit_role_for_type(jsonmodel_type, role)` - when you add a
+new top level JSONModel, register it and its edit role so the listing view can
+determine if the "Edit" button can be displayed to the user.
+
+* `Plugins.register_plugin_section(section)` - allows you define a template to
+be inserted as a section for a given JSONModel record. A section is a type of
+`Plugins::AbstractPluginSection` which defines the source `plugin`, section
+`name`, the `jsonmodel_types` for which the section should show and any `opts`
+required by the templates at the time of render. These new sections (readonly,
+edit and sidebar additions) are output as part of the `PluginHelper` render
+methods.
+
+  `Plugins::AbstractPluginSection` can be subclassed to allow flexible inclusion
+  of arbitrary HTML. There are two examples provided with ArchivesSpace:
+
+  * `Plugins::PluginSubRecord` - uses the `shared/subrecord` partial to output a
+  standard styled ArchivesSpace section. `opts` requires the jsonmodel field to
+  be defined.
+
+  * `Plugins::PluginReadonlySearch` - uses the `search/embedded` partial to
+  output a search listing as a section. `opts` requires the custom filter terms
+  for this search to be defined.
+
+
 ** Further information
 
 Please refer to the `hello_world` exemplar plug-in to find out more about how to implement


### PR DESCRIPTION
Introduces plugin hooks:
- `Plugins.add_resolve_field(field_name)` : add a field to the `ApplicationController.find_opts` "resolve[]" parameter
- `Plugins.register_edit_role_for_type(jsonmodel_type, role)` : hooks into `SearchHelper. can_edit_search_result?`
- `Plugins.register_plugin_section(section)` : allows you define a template to be inserted as a section for a given jsonmodel_type.  A section is a type of `Plugins::AbstractPluginSection` which defines the source plugin, section name, the jsonmodel_types that support the section, and opts required by the template at the time of render.  These new sections (readonly, edit and sidebar additions) are output as part of the PluginHelper render methods.  `Plugins::AbstractPluginSection` can be subclassed to allow flexible inclusion of arbritary data.  I've setup two subclasses:
  - `Plugins::PluginSubRecord` : uses the `shared/subrecord` partial to output a standard styled ASpace section (opts define the jsonmodel field etc)
  - `Plugins::PluginReadonlySearch` uses the `search/embedded` partial to output a search listing as a section (opts define any custom filter terms for this search 