### PR TITLE
Add plugin hooks for "Basic Information"

### DIFF
--- a/frontend/app/models/search_result_data.rb
+++ b/frontend/app/models/search_result_data.rb
@@ -81,6 +81,11 @@ class SearchResultData
   end
 
   def facet_label_string(facet_group, facet)
+    # Plugins can opt to tell us how facet values should be translated.
+    if plugin_key = Plugins.facet_i18n_key(facet_group, facet)
+      return I18n.t(plugin_key, :default => facet)
+    end
+
     return I18n.t("#{facet}._singular", :default => I18n.t("plugins.#{facet}._singular", :default => facet)) if facet_group === "primary_type"
     return I18n.t("enumerations.name_source.#{facet}", :default => I18n.t("enumerations.subject_source.#{facet}", :default => facet)) if facet_group === "source"
     return I18n.t("enumerations.name_rule.#{facet}", :default => facet) if facet_group === "rules"
@@ -237,35 +242,37 @@ class SearchResultData
   end
 
   def self.BASE_FACETS
-    ["primary_type","creators","subjects"]
+    ["primary_type","creators","subjects"] + Plugins.search_facets_for_base
   end
 
   def self.AGENT_FACETS
-    ["primary_type", "source", "rules"]
+    extras = [:agent_person, :agent_family, :agent_corporate_entity, :agent_software]
+               .flat_map {|agent_type| Plugins.search_facets_for_type(agent_type)}
+    ["primary_type", "source", "rules"] + extras
   end
 
   def self.ACCESSION_FACETS
-    ["subjects", "accession_date_year", "creators"]
+    ["subjects", "accession_date_year", "creators"] + Plugins.search_facets_for_type(:accession)
   end
 
   def self.RESOURCE_FACETS
-    ["subjects", "publish", "level", "classification_path", "primary_type"]
+    ["subjects", "publish", "level", "classification_path", "primary_type"] + Plugins.search_facets_for_type(:resource)
   end
 
   def self.DIGITAL_OBJECT_FACETS
-    ["subjects", "publish", "digital_object_type", "level", "primary_type"]
+    ["subjects", "publish", "digital_object_type", "level", "primary_type"] + Plugins.search_facets_for_type(:digital_object)
   end
 
   def self.LOCATION_FACETS
-    ["temporary", "building", "floor", "room", "area", "location_profile_display_string_u_ssort"]
+    ["temporary", "building", "floor", "room", "area", "location_profile_display_string_u_ssort"] + Plugins.search_facets_for_type(:location)
   end
 
   def self.SUBJECT_FACETS
-    ["source", "first_term_type"]
+    ["source", "first_term_type"] + Plugins.search_facets_for_type(:subject)
   end
 
   def self.EVENT_FACETS
-    ["event_type", "outcome"]
+    ["event_type", "outcome"] + Plugins.search_facets_for_type(:event)
   end
 
   def self.UNTITLED_TYPES
@@ -273,11 +280,11 @@ class SearchResultData
   end
 
   def self.CLASSIFICATION_FACETS
-    []
+    [] + Plugins.search_facets_for_type(:classification)
   end
 
   def self.ASSESSMENT_FACETS
-    ['assessment_record_types', 'assessment_surveyors', 'assessment_review_required', 'assessment_reviewers', 'assessment_completed', 'assessment_inactive', 'assessment_survey_year', 'assessment_sensitive_material']
+    ['assessment_record_types', 'assessment_surveyors', 'assessment_review_required', 'assessment_reviewers', 'assessment_completed', 'assessment_inactive', 'assessment_survey_year', 'assessment_sensitive_material'] + Plugins.search_facets_for_type(:assessment)
   end
 
 

--- a/frontend/app/views/accessions/_form.html.erb
+++ b/frontend/app/views/accessions/_form.html.erb
@@ -25,7 +25,11 @@
        <%= form.label_and_textarea "access_restrictions_note" %> 
        <%= form.label_and_boolean "use_restrictions", {}, form.default_for("use_restrictions") %>
        <%= form.label_and_textarea "use_restrictions_note" %> 
-    </fieldset>
+
+      <%= render_plugin_partials("basic_information_accession",
+                                 :form => form,
+                                 :record => @accession) %>
+  </fieldset>
   </section>
 <% end %>
 

--- a/frontend/app/views/accessions/show.html.erb
+++ b/frontend/app/views/accessions/show.html.erb
@@ -39,6 +39,10 @@
             <%= readonly.label_and_boolean "use_restrictions" %>
             <%= readonly.label_and_textarea "use_restrictions_note" %>
 
+            <%= render_plugin_partials("basic_information_accession",
+                                       :form => readonly,
+                                       :record => @accession) %>
+
             <%= display_audit_info(@accession) %>
           </section>
           <% end %>

--- a/frontend/app/views/agents/_form.html.erb
+++ b/frontend/app/views/agents/_form.html.erb
@@ -16,6 +16,11 @@
       </div>
     </div>
     <%= form.label_and_boolean "publish", {}, user_prefs["publish"] %>
+
+    <%= render_plugin_partials("basic_information_#{@agent.agent_type}",
+                               :form => form,
+                               :record => @agent) %>
+
   </section>
 
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "dates_of_existence", :section_id => "#{@agent.agent_type}_dates_of_existence", :template_erb => "dates/template", :template => "existence_date", :heading_text => I18n.t("agent._frontend.section.dates_of_existence"), :template_overrides => {"date_label" => "agents/date_labels"}, :help_topic => "#{@agent.agent_type}_dates_of_existence"} %>
@@ -26,6 +31,6 @@
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_documents", :section_id => "#{@agent.agent_type}_external_documents", :help_topic => "#{@agent.agent_type}_external_documents"} %>
   <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "external_ids", :hidden => true} %>
 
-<%= form_plugins_for("agent", form) %>
+  <%= form_plugins_for("agent", form) %>
 
 </fieldset>

--- a/frontend/app/views/agents/_merge_preview.html.erb
+++ b/frontend/app/views/agents/_merge_preview.html.erb
@@ -18,6 +18,11 @@
             <div class="col-sm-9 label-only"><%= I18n.t("agent.agent_type.#{@agent.agent_type}") %></div>
           </div>
           <%= readonly.label_and_boolean "publish" %>
+
+          <%= render_plugin_partials("basic_information_#{@agent.agent_type}",
+                                     :form => readonly,
+                                     :record => @agent) %>
+
           <%= display_audit_info(@agent) %>
         </section>
 

--- a/frontend/app/views/agents/show.html.erb
+++ b/frontend/app/views/agents/show.html.erb
@@ -21,6 +21,11 @@
             <div class="col-sm-9 label-only"><%= I18n.t("agent.agent_type.#{@agent.agent_type}") %></div>
           </div>
           <%= readonly.label_and_boolean "publish" %>
+
+          <%= render_plugin_partials("basic_information_#{@agent.agent_type}",
+                                     :form => readonly,
+                                     :record => @agent) %>
+
           <%= display_audit_info(@agent) %>
         </section>
 

--- a/frontend/app/views/archival_objects/_form_container.html.erb
+++ b/frontend/app/views/archival_objects/_form_container.html.erb
@@ -49,6 +49,10 @@
         </div>
         <%= form.label_and_boolean "restrictions_apply", {}, form.default_for("restrictions_apply") %>
         <%= form.label_and_textarea "repository_processing_note" %>
+
+        <%= render_plugin_partials("basic_information_archival_object",
+                                   :form => form,
+                                   :record => @archival_object) %>
       </fieldset>
     </section>
   <% end %>

--- a/frontend/app/views/archival_objects/_show_inline.html.erb
+++ b/frontend/app/views/archival_objects/_show_inline.html.erb
@@ -20,6 +20,11 @@
           <%= readonly.label_and_boolean "has_unpublished_ancestor" %>
           <%= readonly.label_and_boolean "restrictions_apply" %>
           <%= readonly.label_and_textarea "repository_processing_note" %>
+
+          <%= render_plugin_partials("basic_information_archival_object",
+                                     :form => readonly,
+                                     :record => @archival_object) %>
+
           <%= display_audit_info(@archival_object) %>
         </section>
 

--- a/frontend/app/views/assessments/_form.html.erb
+++ b/frontend/app/views/assessments/_form.html.erb
@@ -182,6 +182,11 @@
 
       <%= form.label_and_boolean 'inactive' %>
     </fieldset>
+
+    <%= render_plugin_partials("basic_information_assessments",
+                               :form => form,
+                               :record => @assessment) %>
+
   </section>
 
   <section id="rating_attributes" class="subrecord-form-dummy">

--- a/frontend/app/views/classification_terms/_form_container.html.erb
+++ b/frontend/app/views/classification_terms/_form_container.html.erb
@@ -23,6 +23,10 @@
       <%= form.label_and_textfield "title" %>
       <%= form.label_and_textarea "description" %>
 
+      <%= render_plugin_partials("basic_information_classification_term",
+                                 :form => form,
+                                 :record => @classification_term) %>
+
       <% form.push("creator", form["creator"] || {}) do %>
         <%= render_aspace_partial :partial => "agents/linker", :locals => {:form => form, :linker_label => I18n.t("classification_term.creator"), :optional => true, :multiplicity => "one"} %>
       <% end %>

--- a/frontend/app/views/classification_terms/_show_inline.html.erb
+++ b/frontend/app/views/classification_terms/_show_inline.html.erb
@@ -11,11 +11,17 @@
         <% define_template "classification_term", jsonmodel_definition(:classification_term) do |form, classification_term| %>
         <section id="basic_information">
           <h4><%= I18n.t("classification_term._frontend.section.basic_information") %></h4>
-            <%= form.label_and_textarea "identifier" %>
-            <%= form.label_and_textarea "title" %>
-            <%= form.label_and_textarea "description" %>
 
-          <% if !readonly["creator"].blank? %>
+          <%= form.label_and_textarea "identifier" %>
+          <%= form.label_and_textarea "title" %>
+          <%= form.label_and_textarea "description" %>
+
+          <%= render_plugin_partials("basic_information_classification_term",
+                                     :form => form,
+                                     :record => @classification_term) %>
+
+
+  <% if !readonly["creator"].blank? %>
             <div class="token-list">
                 <%= readonly.label_with_field(:creator, render_token(:object => readonly,
                                                              :label => readonly["creator"]["_resolved"]["title"],

--- a/frontend/app/views/classifications/_form_container.html.erb
+++ b/frontend/app/views/classifications/_form_container.html.erb
@@ -18,6 +18,10 @@
       <%= form.label_and_textfield "title" %>
       <%= form.label_and_textarea "description" %>
 
+      <%= render_plugin_partials("basic_information_classification",
+                                 :form => form,
+                                 :record => @classification) %>
+
       <% form.push("creator", form["creator"] || {}) do %>
         <%= render_aspace_partial :partial => "agents/linker", :locals => {:form => form, :linker_label => I18n.t("classification.creator"), :optional => true, :multiplicity => "one"} %>
       <% end %>

--- a/frontend/app/views/classifications/_show_inline.html.erb
+++ b/frontend/app/views/classifications/_show_inline.html.erb
@@ -16,6 +16,10 @@
             <%= form.label_and_textarea "title" %>
             <%= form.label_and_textarea "description" %>
 
+            <%= render_plugin_partials("basic_information_classification",
+                                       :form => form,
+                                       :record => @classification) %>
+
             <% if !readonly["creator"].blank? %>
               <div class="token-list">
                 <%= readonly.label_with_field(:creator, render_token(:object => readonly,

--- a/frontend/app/views/collection_management/show.html.erb
+++ b/frontend/app/views/collection_management/show.html.erb
@@ -72,6 +72,11 @@
                <div class="col-md-9"><%= @collection_management.rights_determined ? I18n.t("collection_management.rights_determined_true") : I18n.t("collection_management.rights_determined_false") %></div>
   
             </div>
+
+            <%= render_plugin_partials("basic_information_collection_management",
+                                       :form => readonly,
+                                       :record => @collection_management) %>
+
           </section>
   
           <section id="collection_management_linked_records_" class="subrecord-form-dummy">

--- a/frontend/app/views/container_profiles/_form.html.erb
+++ b/frontend/app/views/container_profiles/_form.html.erb
@@ -15,7 +15,11 @@
       <%= form.label_and_textfield "height" %>
       <%= form.label_and_textfield "width" %>
       <%= form.label_and_textfield "stacking_limit" %>
-    </fieldset>
+
+      <%= render_plugin_partials("basic_information_container_profile",
+                                 :form => form,
+                                 :record => @container_profile) %>
+  </fieldset>
   </section>
 <% end %>
 

--- a/frontend/app/views/digital_object_components/_form_container.html.erb
+++ b/frontend/app/views/digital_object_components/_form_container.html.erb
@@ -39,6 +39,10 @@
       </div>
       <%= form.label_and_select "language", form.possible_options_for("language", true) %>
 
+      <%= render_plugin_partials("basic_information_digital_object_component",
+                                 :form => form,
+                                 :record => @digital_object_component) %>
+
     </section>
   <% end %>
 

--- a/frontend/app/views/digital_object_components/_show_inline.html.erb
+++ b/frontend/app/views/digital_object_components/_show_inline.html.erb
@@ -60,6 +60,11 @@
           <%= render_aspace_partial :partial => "external_ids/show", :locals => { :external_ids => digital_object_component.external_ids, :context => readonly, :section_id => "digital_object_component_external_ids_" } %>
         <% end %>
 
+        <%= render_plugin_partials("basic_information_digital_object_component",
+                                   :form => readonly,
+                                   :record => @digital_object_component) %>
+
+
         <%= show_plugins_for(@digital_object_component, readonly) %>
 
       <% end %>

--- a/frontend/app/views/digital_objects/_form_container.html.erb
+++ b/frontend/app/views/digital_objects/_form_container.html.erb
@@ -17,6 +17,11 @@
       <%= form.label_and_select "digital_object_type", form.possible_options_for("digital_object_type", true) %>
       <%= form.label_and_select "language", form.possible_options_for("language", true) %>
       <%= form.label_and_boolean "restrictions", {}, form.default_for("restrictions") %>
+
+      <%= render_plugin_partials("basic_information_digital_object",
+                                 :form => form,
+                                 :record => @digital_object) %>
+
     </section>
   <% end %>
 

--- a/frontend/app/views/digital_objects/_show_inline.html.erb
+++ b/frontend/app/views/digital_objects/_show_inline.html.erb
@@ -20,6 +20,11 @@
           <%= readonly.label_and_select "digital_object_type", readonly.possible_options_for("digital_object_type") %>
           <%= readonly.label_and_select "language", readonly.possible_options_for("language") %>
           <%= readonly.label_and_boolean "restrictions" %>
+
+          <%= render_plugin_partials("basic_information_digital_object",
+                                     :form => readonly,
+                                     :record => digital_object) %>
+
           <%= display_audit_info(digital_object) %>
         </section>
 

--- a/frontend/app/views/events/_form.html.erb
+++ b/frontend/app/views/events/_form.html.erb
@@ -10,6 +10,10 @@
       <%= form.label_and_select "event_type", form.possible_options_for("event_type") %>
       <%= form.label_and_select "outcome", form.possible_options_for('outcome', true) %>
       <%= form.label_and_textarea "outcome_note" %>
+
+      <%= render_plugin_partials("basic_information_event",
+                                 :form => form,
+                                 :record => @event) %>
     </fieldset>
   </section>
 <% end %>

--- a/frontend/app/views/jobs/_show_templates.html.erb
+++ b/frontend/app/views/jobs/_show_templates.html.erb
@@ -47,6 +47,11 @@
 
     <% form.emit_template job.job['jsonmodel_type'], job.job %>
 
+    <%= render_plugin_partials("basic_information_job",
+                               :form => form,
+                               :record => @job) %>
+
+
     <%= display_audit_info(@job) %>
   </section>
 <% end %>

--- a/frontend/app/views/location_profiles/_form.html.erb
+++ b/frontend/app/views/location_profiles/_form.html.erb
@@ -16,7 +16,12 @@
       <%= form.label_and_textfield "depth" %>
       <%= form.label_and_textfield "height" %>
       <%= form.label_and_textfield "width" %>
-    </fieldset>
+  
+      <%= render_plugin_partials("basic_information_location_profile",
+                                 :form => form,
+                                 :record => @location_profile) %>
+
+  </fieldset>
   </section>
 <% end %>
 

--- a/frontend/app/views/locations/_form.html.erb
+++ b/frontend/app/views/locations/_form.html.erb
@@ -19,6 +19,10 @@
       <%= form.label_and_textfield "coordinate_3_label" %>
       <%= form.label_and_textfield "coordinate_3_indicator" %>
       <hr/>
+      <%= render_plugin_partials("basic_information_location",
+                                 :form => form,
+                                 :record => @location) %>
+
       <% form.push("location_profile", form.obj["location_profile"] || {}) do %>
         <%= render_aspace_partial :partial => "location_profiles/linker", :locals => {:form => form, :label => I18n.t("location_profile._singular")} %>
       <% end %>

--- a/frontend/app/views/locations/_form_batch.html.erb
+++ b/frontend/app/views/locations/_form_batch.html.erb
@@ -8,6 +8,11 @@
       <%= form.label_and_textfield "floor" %>
       <%= form.label_and_textfield "room" %>
       <%= form.label_and_textfield "area" %>
+
+      <%= render_plugin_partials("basic_information_location",
+                                 :form => form,
+                                 :record => @location) %>
+
       <% form.push("location_profile", form.obj["location_profile"] || {}) do %>
         <%= render_aspace_partial :partial => "location_profiles/linker", :locals => {:form => form, :label => I18n.t("location_profile._singular")} %>
       <% end %>

--- a/frontend/app/views/resources/_form_container.html.erb
+++ b/frontend/app/views/resources/_form_container.html.erb
@@ -28,6 +28,10 @@
       <%= form.label_and_boolean "publish", {}, user_prefs["publish"] %>
       <%= form.label_and_boolean "restrictions", {}, form.default_for("restrictions") %>
       <%= form.label_and_textarea "repository_processing_note" %>
+
+      <%= render_plugin_partials("basic_information_resource",
+                                 :form => form,
+                                 :record => @resource) %>
     </fieldset>
   </section>
 

--- a/frontend/app/views/resources/_show_inline.html.erb
+++ b/frontend/app/views/resources/_show_inline.html.erb
@@ -24,6 +24,11 @@
             <%= readonly.label_and_boolean "publish" %>
             <%= readonly.label_and_boolean "restrictions" %>
             <%= readonly.label_and_textarea "repository_processing_note" %>
+
+            <%= render_plugin_partials("basic_information_resource",
+                                       :form => readonly,
+                                       :record => @resource) %>
+
             <%= display_audit_info(@resource) %>
           </section>
 

--- a/frontend/app/views/subjects/_form.html.erb
+++ b/frontend/app/views/subjects/_form.html.erb
@@ -13,6 +13,10 @@
       <%= form.label_and_textfield "authority_id" %>
       <%= form.label_and_select "source", form.possible_options_for("source", true) %>
       <%= form.label_and_textarea "scope_note" %>
+
+      <%= render_plugin_partials("basic_information_subject",
+                                 :form => form,
+                                 :record => @subject) %>
     </section>
   <% end %>
 

--- a/frontend/app/views/subjects/show.html.erb
+++ b/frontend/app/views/subjects/show.html.erb
@@ -19,6 +19,11 @@
           <%= form.label_and_textfield "authority_id" %>
           <%= form.label_and_select "source", form.possible_options_for("source", true) %>
           <%= form.label_and_textarea "scope_note" %>
+
+          <%= render_plugin_partials("basic_information_subject",
+                                     :form => form,
+                                     :record => @subject) %>
+
           <%= display_audit_info(@subject) %>
         </section>
       <% end %>

--- a/frontend/config/initializers/plugin.rb
+++ b/frontend/config/initializers/plugin.rb
@@ -33,8 +33,47 @@ module Plugins
     @sections = []
     @fields_to_resolve = []
     @edit_roles = []
+
+    @base_facets = []
+    @facets_for_type = {}
+
+    @facet_group_i18n_handlers = {}
   end
 
+
+  def self.add_search_base_facets(*facets)
+    @base_facets ||= []
+    @base_facets += facets
+  end
+
+  def self.add_search_facets(jsonmodel_type, *facets)
+    @facets_for_type[jsonmodel_type.to_s] ||= []
+    @facets_for_type[jsonmodel_type.to_s] += facets
+  end
+
+  def self.search_facets_for_type(jsonmodel_type)
+    @facets_for_type.fetch(jsonmodel_type.to_s, [])
+  end
+
+  def self.search_facets_for_base
+    @base_facets
+  end
+
+  def self.add_facet_group_i18n(facet_group, proc)
+    @facet_group_i18n_handlers[facet_group] = proc
+  end
+
+  # Invoke a handler to determine the i18n key for facet_group and facet.
+  # If there isn't one, return nil.
+  def self.facet_i18n_key(facet_group, facet)
+    handler = @facet_group_i18n_handlers.fetch(facet_group, nil)
+
+    if handler
+      handler.call(facet)
+    else
+      nil
+    end
+  end
 
   def self.system_menu_items
     Array(@config[:system_menu_items]).flatten


### PR DESCRIPTION
Gives plugins the opportunity to add new form fields to the top "Basic
Information" section that is present in most record types.  Sometimes
a new field is just too good to bury in a subrecord!