### PR TITLE
Change the way we handle after_commit hooks in unit tests

### DIFF
--- a/backend/spec/controller_update_feed_spec.rb
+++ b/backend/spec/controller_update_feed_spec.rb
@@ -12,7 +12,9 @@ describe 'Update feed controller' do
       end
     end
 
-    created_accession = create(:json_accession)
+    created_accession = DB.mock_after_commit do
+      create(:json_accession)
+    end
 
     consumer.join
     consumer.value.count.should be == 1

--- a/backend/spec/lib_realtime_indexing_spec.rb
+++ b/backend/spec/lib_realtime_indexing_spec.rb
@@ -10,10 +10,19 @@ describe 'Realtime indexing' do
 
   context "simple updates" do
 
-    let!(:acc) { create(:json_accession) }
-    sleep(0.05)
-    let!(:acc2) { create(:json_accession) }
+    let!(:acc) {
+      DB.mock_after_commit do
+        create(:json_accession)
+      end
+    }
 
+    sleep(0.05)
+
+    let!(:acc2) {
+      DB.mock_after_commit do
+        create(:json_accession)
+      end
+    }
 
     it "records updates" do
       updates = RealtimeIndexing.updates_since(0)
@@ -88,7 +97,10 @@ describe 'Realtime indexing' do
       end
 
       sleep 0.05
-      acc = create(:json_accession)
+
+      acc = DB.mock_after_commit do
+        create(:json_accession)
+      end
 
       result = waiter.join
 


### PR DESCRIPTION
`backend/spec/spec_helper.rb` previously stubbed DB.after_commit to
fire any after commit hooks right away.  This was necessary because
unit tests transactions always get rolled back, so the after commit
hooks would otherwise never run.

A problem with this approach is that after_commit hooks run earlier
in tests than they would in production.  This affects realtime
indexing, which uses after_commit to queue up records: under test
the records emitted by realtime indexing may not be fully formed (for
example, they won't have relationships applied yet).  This never
mattered before, but we've added tests to the series system plugin
that were broken by this behaviour.

To make things more predictable, I've added a `DB.mock_after_commit`
call that lets the test explicitly control when those `after_commit`
calls should happen.  I've updated the tests that make use of
`after_commit` to use this new function.
