### PR TITLE
Update Maven urls to fix issue encountered during fresh install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
 before_script:
 - free -m
 - sleep 3
-- if [[ "$DB" == "mysql" ]]; then (mkdir lib; cd lib; curl -Oq http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar );
+- if [[ "$DB" == "mysql" ]]; then (mkdir lib; cd lib; curl -Oq https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar );
   fi
 - if [[ "$DB" == "mysql" ]]; then export JAVA_OPTS="-Daspace.config.db_url=jdbc:mysql://localhost:3306/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=root";
   fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cd /source && \
     mv ./*.zip / && \
     cd / && \
     unzip /*.zip -d / && \
-    wget http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar && \
+    wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar && \
     cp /mysql-connector-java-5.1.39.jar /archivesspace/lib/
 
 ADD docker-startup.sh /archivesspace/startup.sh

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Download the Connector and place it in a location where ArchivesSpace can
 find it on its classpath:
 
          $ cd lib
-         $ curl -Oq http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar
+         $ curl -Oq https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar
 
 Note that the version of the MySQL connector may be different by the
 time you read this.

--- a/build/build.xml
+++ b/build/build.xml
@@ -5,10 +5,10 @@
   <property name="jruby_url" value="https://repo1.maven.org/maven2/org/jruby/jruby-complete/9.1.17.0/jruby-complete-9.1.17.0.jar" />
   <property name="jruby_file" value="jruby-complete-9.1.17.0.jar" />
 
-  <property name="solr_url" value="http://repo1.maven.org/maven2/org/apache/solr/solr/4.10.4/solr-4.10.4.war" />
+  <property name="solr_url" value="https://repo1.maven.org/maven2/org/apache/solr/solr/4.10.4/solr-4.10.4.war" />
   <property name="solr_file" value="solr-4.10.4.war" />
 
-  <property name="jettyrunner_url" value="http://central.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.2.22.v20170606/jetty-runner-9.2.22.v20170606.jar" />
+  <property name="jettyrunner_url" value="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.2.22.v20170606/jetty-runner-9.2.22.v20170606.jar" />
   <property name="jettyrunner_file" value="jetty-runner-9.2.22.v20170606.jar" />
 
   <property name="gem_home" location="gems" />

--- a/clustering/CLUSTERING_README.md
+++ b/clustering/CLUSTERING_README.md
@@ -170,7 +170,7 @@ library available.  To do this, place it in the `lib/` directory of
 the ArchivesSpace package:
 
      cd /aspace/archivesspace/software/stable/lib
-     wget http://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.24/mysql-connector-java-5.1.24.jar
+     wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.24/mysql-connector-java-5.1.24.jar
 
 
 # Defining a new tenant


### PR DESCRIPTION
Encountered issues while doing a fresh install where I was unable to download required resources due to: requires https errors or "central.maven.org" not being valid (gave a message to use repo1.maven.org)