### PR TITLE
larger sidebar, but still with a resize option (do not merge)

### DIFF
--- a/frontend/app/assets/javascripts/largetree.js.erb
+++ b/frontend/app/assets/javascripts/largetree.js.erb
@@ -572,6 +572,7 @@
 
             row.data('uri', rootNode.uri);
             row.attr('id', TreeIds.uri_to_tree_id(rootNode.uri));
+            row.attr('aria-level', 1);
             row.addClass('root-row');
             row.data('level', 0);
             row.data('child_count', rootNode.child_count);
@@ -735,7 +736,7 @@
                 row.addClass('largetree-node indent-level-' + level);
                 row.data('level', level);
                 row.data('child_count', node.child_count);
-
+                row.attr('aria-level', level + 1);
                 var title = row.find('.title');
                 var strippedTitle = $("<div>").html(node.title).text();
                 title.append($('<a class="record-title" />').prop('href', TreeIds.link_url(node.uri)).text(node.title));

--- a/frontend/app/assets/javascripts/largetree.js.erb
+++ b/frontend/app/assets/javascripts/largetree.js.erb
@@ -753,6 +753,10 @@
                     row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
                 }
 
+                if (node.child_count !== 0) {
+                    row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
+                }
+
                 self.renderer.add_node_columns(row, node);
 
                 var tree_id = TreeIds.uri_to_tree_id(node.uri);

--- a/frontend/app/assets/javascripts/largetree.js.erb
+++ b/frontend/app/assets/javascripts/largetree.js.erb
@@ -750,7 +750,7 @@
                 }
 
                 if (node.child_count !== 0) {
-                    row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
+                    ex.attr('aria-haspopup', true).attr('aria-expanded', false);
                 }
 
                 self.renderer.add_node_columns(row, node);

--- a/frontend/app/assets/javascripts/largetree.js.erb
+++ b/frontend/app/assets/javascripts/largetree.js.erb
@@ -450,6 +450,7 @@
 
         button.find('.expandme-icon').addClass('expanded');
         $(button).data('expanded', true);
+        button.attr('aria-expanded', true);
 
         if (!row.data('uri')) {
             debugger;
@@ -476,9 +477,9 @@
         }
 
         var button = row.find('.expandme');
-
         $(button).data('expanded', false);
         button.find('.expandme-icon').removeClass('expanded');
+        button.attr('aria-expanded', false);
 
         /* Removing elements might have scrolled something else into view */
         setTimeout(function () {
@@ -745,6 +746,10 @@
                 if (node.child_count === 0) {
                     ex.css('visibility', 'hidden');
                     ex.attr('aria-hidden', 'true');
+                }
+
+                if (node.child_count !== 0) {
+                    row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
                 }
 
                 self.renderer.add_node_columns(row, node);

--- a/frontend/app/assets/javascripts/largetree.js.erb
+++ b/frontend/app/assets/javascripts/largetree.js.erb
@@ -753,10 +753,6 @@
                     row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
                 }
 
-                if (node.child_count !== 0) {
-                    row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
-                }
-
                 self.renderer.add_node_columns(row, node);
 
                 var tree_id = TreeIds.uri_to_tree_id(node.uri);

--- a/public/app/assets/javascripts/resizable_sidebar.js
+++ b/public/app/assets/javascripts/resizable_sidebar.js
@@ -2,7 +2,7 @@ function ResizableSidebar($sidebar) {
     this.$sidebar = $sidebar;
 
     this.$row = $sidebar.closest('.row');
-    this.$content_pane = this.$row.find('> .col-sm-9');
+    this.$content_pane = this.$row.find('> .col-sm-8');
 
     if (this.$content_pane.length == 0) {
         // only do things if there's a content pane and a sidebar

--- a/public/vendor/assets/javascripts/largetree.js.erb
+++ b/public/vendor/assets/javascripts/largetree.js.erb
@@ -755,6 +755,10 @@
                     row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
                 }
 
+                if (node.child_count !== 0) {
+                    row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
+                }
+
                 self.renderer.add_node_columns(row, node);
 
                 var tree_id = TreeIds.uri_to_tree_id(node.uri);

--- a/public/vendor/assets/javascripts/largetree.js.erb
+++ b/public/vendor/assets/javascripts/largetree.js.erb
@@ -752,7 +752,7 @@
                 }
 
                 if (node.child_count !== 0) {
-                    row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
+                    ex.attr('aria-haspopup', true).attr('aria-expanded', false);
                 }
 
                 self.renderer.add_node_columns(row, node);

--- a/public/vendor/assets/javascripts/largetree.js.erb
+++ b/public/vendor/assets/javascripts/largetree.js.erb
@@ -755,10 +755,6 @@
                     row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
                 }
 
-                if (node.child_count !== 0) {
-                    row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
-                }
-
                 self.renderer.add_node_columns(row, node);
 
                 var tree_id = TreeIds.uri_to_tree_id(node.uri);

--- a/public/vendor/assets/javascripts/largetree.js.erb
+++ b/public/vendor/assets/javascripts/largetree.js.erb
@@ -452,6 +452,7 @@
 
         button.find('.expandme-icon').addClass('expanded');
         $(button).data('expanded', true);
+        button.attr('aria-expanded', true);
 
         if (!row.data('uri')) {
             debugger;
@@ -478,9 +479,9 @@
         }
 
         var button = row.find('.expandme');
-
         $(button).data('expanded', false);
         button.find('.expandme-icon').removeClass('expanded');
+        button.attr('aria-expanded', false);
 
         /* Removing elements might have scrolled something else into view */
         setTimeout(function () {
@@ -747,6 +748,10 @@
                 if (node.child_count === 0) {
                     ex.css('visibility', 'hidden');
                     ex.attr('aria-hidden', 'true');
+                }
+
+                if (node.child_count !== 0) {
+                    row.find('.expandme').attr('aria-haspopup', true).attr('aria-expanded', false);
                 }
 
                 self.renderer.add_node_columns(row, node);

--- a/public/vendor/assets/javascripts/largetree.js.erb
+++ b/public/vendor/assets/javascripts/largetree.js.erb
@@ -574,6 +574,7 @@
 
             row.data('uri', rootNode.uri);
             row.attr('id', TreeIds.uri_to_tree_id(rootNode.uri));
+            row.attr('aria-level', 1);
             row.addClass('root-row');
             row.data('level', 0);
             row.data('child_count', rootNode.child_count);
@@ -737,7 +738,7 @@
                 row.addClass('largetree-node indent-level-' + level);
                 row.data('level', level);
                 row.data('child_count', node.child_count);
-
+                row.attr('aria-level', level + 1);
                 var title = row.find('.title');
                 var strippedTitle = $("<div>").html(node.title).text();
                 title.append($('<a class="record-title" />').prop('href', TreeIds.link_url(node.uri)).text(node.title));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Probably not something to merge.  

We went live without the resize bar being operational at all because there are problems with it when zooming in and out with the browser.  However, since we did widen our sidebar by adjusting the Bootstrap 3 grid layouts, that lone change breaks this javascript resize functionality.  Could this be updated to use an ID or another CSS classname that's not tied to the layout?  Not sure when ASpace will migrate away from BS3, but I assume it might happen alongside the next major release comes out.

## Description
<!--- Describe your changes in detail -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
