### PR TITLE
Kstemmer

### DIFF
--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -350,6 +350,8 @@
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         -->
         <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.KStemFilterFactory"/>
 	<filter class="solr.ASCIIFoldingFilterFactory"/>
       </analyzer>
       <analyzer type="query">
@@ -359,6 +361,8 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.KStemFilterFactory"/>
 	<filter class="solr.ASCIIFoldingFilterFactory"/>
       </analyzer>
     </fieldType>

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -344,7 +344,6 @@
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="org.archivesspace.solr.ArchivesSpacePunctuationFilterFactory" />
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <!-- in this example, we will only use synonyms at query time
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
@@ -352,16 +351,17 @@
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KStemFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="org.archivesspace.solr.ArchivesSpacePunctuationFilterFactory" />
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- <tokenizer class="solr.WhitespaceTokenizerFactory"/> -->
-        <filter class="org.archivesspace.solr.ArchivesSpacePunctuationFilterFactory" />
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KStemFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="org.archivesspace.solr.ArchivesSpacePunctuationFilterFactory" />
       </analyzer>
     </fieldType>
 

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -350,9 +350,8 @@
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         -->
         <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.ASCIIFoldingFilterFactory"/>
         <filter class="solr.KStemFilterFactory"/>
-	<filter class="solr.ASCIIFoldingFilterFactory"/>
+	      <filter class="solr.ASCIIFoldingFilterFactory"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -361,9 +360,8 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.ASCIIFoldingFilterFactory"/>
         <filter class="solr.KStemFilterFactory"/>
-	<filter class="solr.ASCIIFoldingFilterFactory"/>
+	      <filter class="solr.ASCIIFoldingFilterFactory"/>
       </analyzer>
     </fieldType>
 

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -351,7 +351,7 @@
         -->
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KStemFilterFactory"/>
-	      <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.ASCIIFoldingFilterFactory"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -361,7 +361,7 @@
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KStemFilterFactory"/>
-	      <filter class="solr.ASCIIFoldingFilterFactory"/>
+        <filter class="solr.ASCIIFoldingFilterFactory"/>
       </analyzer>
     </fieldType>
 

--- a/solr/synonyms.txt
+++ b/solr/synonyms.txt
@@ -1,0 +1,1 @@
+dog, dogs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds the Krovetz Stemmer back, which we've had in production to handle simple stemming.  This works great, aside from two issues:

1.  It can occasionally break the typeahead search in the staff interface, since you need to remember to search for "volume" instead of "volumes", since as soon as you type in a trailing 's', you do not get any results.
2.  For some reason I don't understand, Solr's KStemmer does *not* stem "dogs" to "dog".  However, being able to search for either term and get the same results was one of our original search requirements.  To fix that issue, we've had "dog, dogs" in our synonyms.txt file in production, which this pull request adds back.  But we really need to add some other synonyms.

## Description
<!--- Describe your changes in detail -->

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
